### PR TITLE
feat: Add "Link Preference"

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -209,6 +209,7 @@ function App() {
                   isFirst={index === 0}
                   isLast={index === filteredGroups.length - 1}
                   theme={settings.theme}
+                  linkTarget={settings.linkTarget}
                   spaceId={activeSpace.id}
                   onAddBookmark={handleAddBookmark}
                 />

--- a/src/components/BookmarkGroup.tsx
+++ b/src/components/BookmarkGroup.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { ChevronUp, ChevronDown, Trash2, Settings, Plus } from 'lucide-react';
 import { useDroppable } from '@dnd-kit/core';
 import { BookmarkTile } from './BookmarkTile';
-import type { BookmarkGroup as BookmarkGroupType, Bookmark } from '../types';
+import type { BookmarkGroup as BookmarkGroupType, Bookmark, LinkTarget } from '../types';
 import toast from 'react-hot-toast';
 import { BookmarkEditModal } from './BookmarkEditModal';
 import { AddBookmarkModal } from './AddBookmarkModal';
@@ -19,6 +19,7 @@ interface BookmarkGroupProps {
   isFirst: boolean;
   isLast: boolean;
   theme: 'light' | 'dark';
+  linkTarget: LinkTarget;
   spaceId: string;
 }
 
@@ -34,6 +35,7 @@ export function BookmarkGroup({
   isFirst,
   isLast,
   theme,
+  linkTarget,
   spaceId,
 }: BookmarkGroupProps) {
   const { setNodeRef, isOver } = useDroppable({
@@ -186,6 +188,7 @@ export function BookmarkGroup({
                 isFirst={index === 0}
                 isLast={index === group.bookmarks.length - 1}
                 theme={theme}
+                linkTarget={linkTarget}
               />
             ))}
           </div>

--- a/src/components/BookmarkTile.tsx
+++ b/src/components/BookmarkTile.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Edit2, Trash2, ChevronLeft, ChevronRight } from 'lucide-react';
-import type { Bookmark } from '../types';
+import type { Bookmark, LinkTarget } from '../types';
 
 interface BookmarkTileProps {
   bookmark: Bookmark;
@@ -11,6 +11,7 @@ interface BookmarkTileProps {
   isFirst: boolean;
   isLast: boolean;
   theme: 'light' | 'dark';
+  linkTarget: LinkTarget;
 }
 
 export function BookmarkTile({
@@ -21,7 +22,8 @@ export function BookmarkTile({
   onMove,
   isFirst,
   isLast,
-  theme
+  theme,
+  linkTarget
 }: BookmarkTileProps) {
   const hexToRgba = (hex: string, alpha: number) => {
     const r = parseInt(hex.slice(1, 3), 16);
@@ -33,7 +35,7 @@ export function BookmarkTile({
   const handleTileClick = (e: React.MouseEvent) => {
     // Ensure the click is on the tile itself or within the bookmark content
     if (e.target === e.currentTarget || (e.target as HTMLElement).closest('.bookmark-content')) {
-      window.open(bookmark.url, '_blank', 'noopener,noreferrer');
+      window.open(bookmark.url, linkTarget, 'noopener,noreferrer');
     }
   };
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -159,7 +159,7 @@ export function SettingsModal({
                 <span className={`text-sm font-medium ${
                   theme === 'dark' ? 'text-gray-200' : 'text-gray-700'
                 }`}>
-                  Link Preference
+                  Open bookmarks in
                 </span>
                 <div className={`inline-flex overflow-hidden border hover:border-blue-500 rounded-lg text-sm font-medium ${
                   theme === 'dark' ? "border-gray-600" : "border-gray-300"

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { X, Moon, Sun, Download, Upload, Loader2 } from 'lucide-react';
 import toast from 'react-hot-toast';
-import type { AppSettings, BookmarkExport } from '../types';
+import { LinkTarget, type AppSettings, type BookmarkExport } from '../types';
 
 interface SettingsModalProps {
   settings: AppSettings;
@@ -51,6 +51,10 @@ export function SettingsModal({
       setIsThemeButtonChanging(false);
     }, 300);
   };
+
+  const handleLinkTargetToggle = (linkTarget: LinkTarget) => {
+    setCurrentSettings((currentSettings) => ({...currentSettings, linkTarget}));
+  }
 
   const handleImportClick = () => {
     setShowImportOptions(true);
@@ -145,6 +149,48 @@ export function SettingsModal({
                     <Moon className="w-5 h-5" />
                   )}
                 </button>
+              </label>
+            </div>
+
+            <div className={`border-t pt-6 ${
+              theme === 'dark' ? 'border-gray-700' : 'border-gray-200'
+            }`}>
+              <label className="flex items-center justify-between">
+                <span className={`text-sm font-medium ${
+                  theme === 'dark' ? 'text-gray-200' : 'text-gray-700'
+                }`}>
+                  Link Preference
+                </span>
+                <div className={`inline-flex overflow-hidden border hover:border-blue-500 rounded-lg text-sm font-medium ${
+                  theme === 'dark' ? "border-gray-600" : "border-gray-300"
+                }`}>
+                  <button
+                    type="button"
+                    onClick={() => handleLinkTargetToggle(LinkTarget.NEW)}
+                    className={`px-4 py-2 ${
+                      currentSettings.linkTarget === LinkTarget.NEW
+                        ? "bg-blue-500 text-white"
+                        : settings.theme === "dark"
+                          ? "text-gray-200"
+                          : "bg-white text-gray-700"
+                    }`}
+                  >
+                    New Tab
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleLinkTargetToggle(LinkTarget.CURRENT)}
+                    className={`px-4 py-2 ${
+                      currentSettings.linkTarget === LinkTarget.CURRENT
+                        ? "bg-blue-500 text-white"
+                        : settings.theme === "dark"
+                          ? "text-gray-200"
+                          : "bg-white text-gray-700"
+                    }`}
+                  >
+                    Current Tab
+                  </button>
+                </div>
               </label>
             </div>
 

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
-import type { AppSettings } from '../types';
+import { LinkTarget, type AppSettings } from '../types';
 
 const defaultSettings: AppSettings = {
   theme: 'light',
   hasCompletedSetup: false,
   rightPanelCollapsed: false,
+  linkTarget: LinkTarget.NEW,
 };
 
 export function useSettings() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,10 +26,16 @@ export interface OpenTab {
   url: string;
 }
 
+export enum LinkTarget {
+  NEW = '_blank',
+  CURRENT = '_self',
+}
+
 export interface AppSettings {
   theme: 'light' | 'dark';
   hasCompletedSetup: boolean;
   rightPanelCollapsed: boolean;
+  linkTarget:  LinkTarget;
 }
 
 export interface BookmarkExport {


### PR DESCRIPTION
As a user, I want to have an option
to open the link either in current tab
or new tab.

This change adds the ability to do that.
By default the preference would be new
tab as it was before. The user can update
the preference from settings dialog.